### PR TITLE
Bug fix: display links in venue section

### DIFF
--- a/index.html
+++ b/index.html
@@ -278,7 +278,7 @@
 						<div class="col-sm-12 text-center">
 							<h1>Proudly supported by</h1>
 						</div>
-					   
+
                         <div class="col-md-4 col-sm-6 sponsor-column">
 				            <div class="sponsor text-center">
 								<a href="http://mbm.asia" target="default">
@@ -286,7 +286,7 @@
 								</a>
 							</div>
                         </div>
-                        
+
                         <div class="col-md-4 col-sm-6 sponsor-column">
 				            <div class="sponsor text-center">
 								<a href="http://lli.sg" target="default">
@@ -294,12 +294,12 @@
 								</a>
 							</div>
 				        </div>
-                        
+
                         <div class="col-sm-12 text-center">
 							<span>Interested in becoming a sponsor? <a href="mailto:contact@fossasia.org" target="default">Get in touch</a></span>
-						</div>		
+						</div>
                     </div>
-					
+
                     <!--			<div class="col-md-4 col-sm-6 sponsor-column">
 								<div class="sponsor text-center">
 									<a href="https://www.google.com/cloud/" target="default">
@@ -371,7 +371,7 @@
 
 
 
-							
+
 
 <!--
 							<div class="col-md-4 col-sm-6 sponsor-column">
@@ -2235,10 +2235,10 @@ Andrey Terekhov is responsible for defining Microsoft’s open source strategy a
               <!-- Parameters documentation at https://github.com/fossasia/fossasia-loklak-webtweets/blob/gh-pages/README.md -->
                             <div class="tweets-feed" data-count=3 data-query="fossasia">
                             </div>
-                            <span class="text-white">Follow <a target="default" href="https://twitter.com/fossasia">@fossasia</a> for more updates</span>
+                            <span class="text-white">Follow <a target="default" href="https://twitter.com/fossasia"><span class="text-white">@fossasia</span></a> for more updates</span>
                            <img class="icon social_rss" src="img/rss.png" alt="rss">
                            <div id="result"></div>
-                            <span class="text-white"><a target="default" href="https://www.lli.sg/">Lifelong Learning Institute Singapore</a> is the event location for the FOSSASIA Summit. Address: 11 Eunos Road 8, Singapore 408601 (Paya Lebar MRT).</span>
+                            <span class="text-white"><a target="default" href="https://www.lli.sg/"><span class="text-white">Lifelong Learning Institute Singapore</span></a> is the event location for the FOSSASIA Summit. Address: 11 Eunos Road 8, Singapore 408601 (Paya Lebar MRT).</span>
 		<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js" ></script>
                         </div>
                         <div class=" col-md-5 col-sm-6" id="overlay">


### PR DESCRIPTION
There was an issue in the venue section in which some text was not getting displayed due to missing span which i have fixed.
Before:
<img width="562" alt="screen shot 2017-09-20 at 7 42 40 pm" src="https://user-images.githubusercontent.com/22093105/30648986-fa834fa0-9e3c-11e7-882b-a1f050c10285.png">
After:
<img width="573" alt="screen shot 2017-09-20 at 7 42 53 pm" src="https://user-images.githubusercontent.com/22093105/30648987-fa86c7b6-9e3c-11e7-8084-40f4b6e67d2a.png">
