### PR TITLE
Center aligned team members on mobile screens

### DIFF
--- a/css/theme-lava.css
+++ b/css/theme-lava.css
@@ -1357,10 +1357,13 @@ nav .container {
 @media all and (max-width: 767px) {
   .speaker-with-bio .speaker {
     width: 100%;
+    float: none;
+    margin: auto;
   }
   .speaker-with-bio .speaker-description {
     width: 100%;
     padding-left: 0px;
+    text-align: center;
   }
 }
 .topics {


### PR DESCRIPTION
Initially team member is left aligned. I aligned member to center which look great. This PR only affect mobile screens, desktop view will remain same as before.
Before:
![screen shot 2017-10-05 at 13 59 02](https://user-images.githubusercontent.com/20956124/31218538-4664f2c4-a9d8-11e7-9844-fbdbf4ce0865.png)

After:
![screen shot 2017-10-05 at 14 15 58](https://user-images.githubusercontent.com/20956124/31218547-4f4fc904-a9d8-11e7-823b-a57e28663244.png)
