### PR TITLE
Fix #389: Navigation bar options not properly aligned

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -177,3 +177,12 @@
     clear: left;
   }
 }
+
+@media (min-width: 769px) and (max-width: 991px) {
+  nav .logo {
+    top: -18px;
+  }
+  .menu li {
+    margin-right: 27px;
+  }
+}


### PR DESCRIPTION
Fixes #389 
Added some CSS to fix navbar (for browser screen width b/w 769px & 991px)
Before:
![img22](https://user-images.githubusercontent.com/25399108/36090880-f45da67e-1007-11e8-81a8-5f731647640c.JPG)

After:
![img2](https://user-images.githubusercontent.com/25399108/36090889-fe25ee64-1007-11e8-86db-3b894957df27.JPG)

Preview: Since this is from a branch on my fork, I can't generate a preview on Github pages, as it's allowed from the master branch only. One way to see the changes _locally_ would be as follows:
1) Clone my repo from [https://github.com/apooravc/2018.fossasia.org](https://github.com/apooravc/2018.fossasia.org)
2) After cloning, only the master branch would be available locally. Enter `git checkout -b fix-navbar origin/fix-navbar` to get the branch _fix-navbar_ locally.
3) The changes could then be seen on the home page.

@hpdang @mariobehling Please have a look.