### PR TITLE
Fixed #493: Move Douglas Gray & Jonas von Malottki to Featured Speakers section

### DIFF
--- a/index.html
+++ b/index.html
@@ -749,6 +749,32 @@
                             </div>
                         </div>
                     </div>
+
+                    <div class="col-md-6 col-sm-12 speaker-outer">
+                        <div class="speaker-with-bio">
+                            <div class="speaker">
+                                <div class="image-holder">
+                                    <img class="background-image" alt="Jonas von Malottki" src="img/JonasvonMalottki.jpg">
+                                    <div class="hover-state text-center preserve3d">
+                                        <div class="social-links vertical-align">
+                                            <a target="default" href="https://www.daimler.com">
+                                              <i class="icon fa fa-external-link"></i>
+                                            </a>
+                                            <a target="default" href="https://www.linkedin.com/in/jonas-von-malottki/">
+                                                <i class="icon social_linkedin"></i>
+                                            </a>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="speaker-description">
+                                <h2>Jonas von Malottki</h2>
+                                <span class="sub">Daimler</span>
+                                <p>Jonas holds a Diploma in Computer Science and Japanese Studies from University of Bonn. Main focus topics where Metadata and Data Quality as well as Neural Networks. Within Daimler he previously was in lead architecture roles for Finance Systems and various leadership positions. He has a keen interest in new technologies and the Open Source movement. In his current role he is shaping the Blockchain and DLT activities from the technology perspective within Daimler. As a Member of the Governing Board of Hyperledger he is also representing that role internationally.</p>
+                            </div>
+                        </div>
+                    </div>
+
                 </div>
             </div>
         </section>
@@ -1523,27 +1549,6 @@
                         <div class="speaker-bio-tooltip-pin"></div>
                         <div class="speaker-bio-tooltip">
                             <div class="speaker-bio-tooltip-content">Highly skilled Linux/FreeBSD DevOps/SRE and PostgreSQL DBA with over 15 years of experience</div>
-                        </div>
-                    </div>
-
-                    <div class="col-md-3 col-sm-6 speaker-column">
-                        <div class="speaker">
-                            <div class="image-holder">
-                                <img class="background-image" alt="Ken Soh" src="img/JonasvonMalottki.jpg">
-                                <div class="hover-state text-center preserve3d">
-                                    <div class="social-links vertical-align">
-                                        <a target="default" href="https://www.daimler.com">
-                                            <i class="icon fa fa-external-link"></i>
-                                        </a>
-                                        <a target="default" href="https://www.linkedin.com/in/jonas-von-malottki/">
-                                            <i class="icon social_linkedin"></i>
-                                        </a>
-                                    </div>
-                                </div>
-                            </div>
-                            <span class="speaker-name">Jonas von Malottki</span>
-                            <span>Senior Manager Finance</span>
-                            <span>Daimler</span>
                         </div>
                     </div>
 


### PR DESCRIPTION
Fixes: #493 
Moved speaker Jonas von Malottki to Featured Speakers section.
Deployment link: https://simsausaurabh.github.io/2018.fossasia.org/
@mariobehling please preview.