### PR TITLE
Fixed #506: Change the "Book your booth" button into a hollow button

### DIFF
--- a/index.html
+++ b/index.html
@@ -1120,7 +1120,7 @@
 										<p class="lead">
 											Meet top tech companies like Google, Daimler/Mercedes, and Microsoft at the exhibition, discuss job and career strategies with Indeed or learn about the latest tech ideas from core developers of projects like VLC, Debian, CentOS, FreeBSD and many more at the exhibition.</p>
 											<p class="lead">The exhibition opens on Thursday, March 22 at 12pm with a reception and runs daily from 10am - 6pm until Saturday evening (March 24).</p>
-										<a href="./exhibitors/index.html" class="btn" target="_self">Book Your Booth</a>
+										<a class="btn" target="_self">Book Your Booth</a>
 									</li>
 								</ul>
 							</div>


### PR DESCRIPTION
Fixes: #506 
Changed the "Book your booth" button into a hollow button.
Deployment link: https://simsausaurabh.github.io/2018.fossasia.org/