### PR TITLE
Fixed #506: Change the "Book your booth" button into a hollow button

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -225,3 +225,14 @@
     margin-right: 27px;
   }
 }
+
+.btn-hollow-red {
+  color: #e12b00 !important;
+  border: 2px solid #e12b00 !important;
+  background: transparent !important;
+}
+
+.btn-hollow-red:hover {
+    color: #fff !important;
+    background: #e12b00 !important;
+}

--- a/index.html
+++ b/index.html
@@ -1148,7 +1148,7 @@
 										<p class="lead">
 											Meet top tech companies like Google, Daimler/Mercedes, and Microsoft at the exhibition, discuss job and career strategies with Indeed or learn about the latest tech ideas from core developers of projects like VLC, Debian, CentOS, FreeBSD and many more at the exhibition.</p>
 											<p class="lead">The exhibition opens on Thursday, March 22 at 12pm with a reception and runs daily from 10am - 6pm until Saturday evening (March 24).</p>
-										<a href="./exhibitors/index.html" class="btn" target="_self">Book Your Booth</a>
+										<a href="./exhibitors/index.html" class="btn btn-hollow-red" target="_self">Book Your Booth</a>
 									</li>
 								</ul>
 							</div>


### PR DESCRIPTION
Fixes: #506 
Changed the "Book your booth" button into a hollow button.
Deployment link: https://simsausaurabh.github.io/2018.fossasia.org/