### PR TITLE
fixed booth listing area links to red

### DIFF
--- a/exhibition/index.html
+++ b/exhibition/index.html
@@ -447,14 +447,14 @@
 
         <a id="exhibitors" class="in-page-link"></a>
 
-            <section class="schedule-with-text">
+            <section class="schedule">
                 <div class="container">
                     <div class="row">
                         <div class="col-md-4 col-sm-4">
                             <h1>FOSSASIA Summit Exhibitors Overview</h1>
                             <p>
                                 The FOSSASIA Summit exhibition is the opportunity to meet FOSS companies and projects from around the world. Learn about the latest Open Source technologies, meet representatives to discuss job opportunities, get your gadget in a hands-on lab and socialize in the exhibition lounge area.</p>
-                            <a href="../tickets/index.html" class="btn">Buy a ticket</a>
+                            <a href="../tickets/index.html" class="btn" style="color: white">Buy a ticket</a>
                         </div>
 
                         <div class="col-sm-6 col-md-4">


### PR DESCRIPTION
Fixes #519

Fixed booth listing area's link colors to red on the exhibitions page.

preview link : https://prshntsingh.github.io/2018.fossasia.org/exhibition/#exhibitors

@mariobehling