### PR TITLE
fix color issue with exhibition page (issue#512)

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -95,6 +95,10 @@
   border-color: #C3BFBF;
   margin-top: 2px;
 }
+a:focus, a:hover {
+    color: #9fab9e;
+    text-decoration:none;
+}
 /*css classes for hiding and showing Donation and regular supporter parts in donate.html*/
 .appear{
   display: block;


### PR DESCRIPTION
Fixes #512 

color of link changed from blue to grey.
![link](https://user-images.githubusercontent.com/30981465/36959387-bd0a9176-2067-11e8-901c-b2e0b548bc46.png)

preview link : https://rawgit.com/PrP-11/2018.fossasia.org/b1/exhibition/index.html

and for font color if we change them to white then text will disappear as background is also white.
